### PR TITLE
(+semver: breaking) Fixed typo in name of metric

### DIFF
--- a/grpc/metrics.go
+++ b/grpc/metrics.go
@@ -16,7 +16,7 @@ func newServiceMetrics(serviceName string) serviceMetrics {
 
 	return serviceMetrics{
 		activeStreams: promauto.NewGauge(prometheus.GaugeOpts{
-			Name:        "grpc_server_active_strams",
+			Name:        "grpc_server_active_streams",
 			Help:        "The total number of streams connected to the service",
 			ConstLabels: labels,
 		}),

--- a/grpc/streamInterceptor.go
+++ b/grpc/streamInterceptor.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	streamingCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "grpc_server_active_strams",
+		Name: "grpc_server_active_streams",
 		Help: "The total number of streams connected to the service",
 	}, []string{
 		"grpc_type",


### PR DESCRIPTION
I've marked this as breaking because it will require updates to downstream uses of this metric name. 