### PR TITLE
(+semver: breaking) Updates to docker testing functions to support port forwarding

### DIFF
--- a/database/postgres.go
+++ b/database/postgres.go
@@ -14,6 +14,7 @@ import (
 // PostgresDatabaseSettings are the settings for a timescale database
 type PostgresDatabaseSettings struct {
 	Host     string
+	Port     int
 	User     string
 	Password string
 	Name     string
@@ -99,10 +100,18 @@ func (ds *PostgresDatabaseSettings) MigrateUpWithStatik(subdirectory string) err
 	return nil
 }
 
+func (ds *PostgresDatabaseSettings) getPort() int {
+	if ds.Port != 0 {
+		return ds.Port
+	}
+
+	return 5432
+}
+
 func (ds *PostgresDatabaseSettings) getConnectionStringWithoutDatabase() string {
-	return fmt.Sprintf("user=%s password=%s host=%s sslmode=disable", ds.User, ds.Password, ds.Host)
+	return fmt.Sprintf("user=%s password=%s host=%s port=%d sslmode=disable", ds.User, ds.Password, ds.Host, ds.getPort())
 }
 
 func (ds *PostgresDatabaseSettings) getConnectionStringWithDatabase() string {
-	return fmt.Sprintf("user=%s password=%s host=%s dbname=%s sslmode=disable", ds.User, ds.Password, ds.Host, ds.Name)
+	return fmt.Sprintf("user=%s password=%s host=%s port=%d dbname=%s sslmode=disable", ds.User, ds.Password, ds.Host, ds.getPort(), ds.Name)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Shopify/sarama v1.24.1
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3
+	github.com/docker/go-connections v0.4.0
 	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/golang-migrate/migrate/v4 v4.8.0
 	github.com/golang/protobuf v1.3.2
@@ -14,6 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/klauspost/cpuid v1.2.3 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/rakyll/statik v0.1.6
@@ -21,7 +23,7 @@ require (
 	github.com/syncromatics/proto-schema-registry v0.7.2
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a
+	github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a // indirect
 	go.uber.org/zap v1.13.0
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	google.golang.org/grpc v1.25.1

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.2.6+incompatible h1:6aCX4/YZ9v8q69hTyiR7dNLnTA3fgtKHVVW5BCd5Znw=
 github.com/pierrec/lz4 v2.2.6+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/testing/docker/etcd_setup_test.go
+++ b/testing/docker/etcd_setup_test.go
@@ -1,0 +1,35 @@
+package docker_test
+
+import (
+	"fmt"
+
+	"github.com/syncromatics/go-kit/testing/docker"
+)
+
+func ExampleSetupEtcd() {
+	etcdURL, err := docker.SetupEtcd("test")
+	if err != nil {
+		panic(err)
+	}
+	
+	fmt.Printf("etcdURL is set: %t\n", etcdURL != "")
+	/*
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{etcdURL},
+		DialTimeout: 5*time.Second,
+	})
+	if err != nil {
+		panic(err)
+	}
+	
+	// snip
+	
+	err = cli.Close()
+	if err != nil {
+		panic(err)
+	}
+	*/
+
+	docker.TeardownEtcd("test")
+	// Output: etcdURL is set: true
+}

--- a/testing/docker/kafka_setup_test.go
+++ b/testing/docker/kafka_setup_test.go
@@ -1,0 +1,19 @@
+package docker_test
+
+import (
+	"fmt"
+
+	"github.com/syncromatics/go-kit/testing/docker"
+)
+
+func ExampleSetupKafka() {
+	setup, err := docker.SetupKafka("test")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Kafka broker and proto registry hosts are set: %t", setup.ExternalBroker != "" && setup.ProtoRegistry != "")
+	
+	docker.TeardownKafka("test")
+	// Output: Kafka broker and proto registry hosts are set: true
+}

--- a/testing/docker/mssql_setup.go
+++ b/testing/docker/mssql_setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"time"
@@ -12,19 +13,30 @@ import (
 	"docker.io/go-docker/api/types"
 	"docker.io/go-docker/api/types/container"
 	"docker.io/go-docker/api/types/network"
+	"github.com/docker/go-connections/nat"
+	"github.com/phayes/freeport"
 	"github.com/pkg/errors"
 )
 
 var (
-	databaseImage = "mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04"
+	mssqlImage = "mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04"
 )
 
 // MSSqlDatabaseSettings is the settings for the database
 type MSSqlDatabaseSettings struct {
 	Host     string
+	Port     int
 	User     string
 	Password string
 	Name     *string
+}
+
+func (ds *MSSqlDatabaseSettings) getPort() int {
+	if ds.Port != 0 {
+		return ds.Port
+	}
+
+	return 1433
 }
 
 // GetDB will return a database instance from the settings
@@ -38,7 +50,7 @@ func (ds *MSSqlDatabaseSettings) GetDB() (*sql.DB, error) {
 	u := &url.URL{
 		Scheme:   "sqlserver",
 		User:     url.UserPassword(ds.User, ds.Password),
-		Host:     fmt.Sprintf("%s:%d", ds.Host, 1433),
+		Host:     fmt.Sprintf("%s:%d", ds.Host, ds.getPort()),
 		RawQuery: query.Encode(),
 	}
 	db, err := sql.Open("sqlserver", u.String())
@@ -78,9 +90,9 @@ type DatabaseSetup struct {
 	DatabaseName  *string
 }
 
-// SetupAdminDatabase will setup a test database
-func SetupAdminDatabase(setup DatabaseSetup) (*MSSqlDatabaseSettings, error) {
-	containerName := fmt.Sprintf("%s_database_test", setup.TestName)
+// SetupMSSqlDatabase sets up a Microsoft SQL Server database
+func SetupMSSqlDatabase(setup DatabaseSetup) (*MSSqlDatabaseSettings, error) {
+	containerName := fmt.Sprintf("%s_mssql", setup.TestName)
 
 	os.Setenv("DOCKER_API_VERSION", "1.35")
 	cli, err := client.NewEnvClient()
@@ -88,17 +100,49 @@ func SetupAdminDatabase(setup DatabaseSetup) (*MSSqlDatabaseSettings, error) {
 		return nil, err
 	}
 
-	image := databaseImage
+	image := mssqlImage
 	if setup.DatabaseImage != nil {
 		image = *setup.DatabaseImage
 	}
 
-	config := container.Config{
-		Image: image,
+	r, err := cli.ImagePull(context.Background(), image, types.ImagePullOptions{})
+	if err != nil {
+		return nil, err
 	}
 
-	hostConfig := container.HostConfig{}
+	_, err = ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
 
+	err = r.Close()
+	if err != nil {
+		return nil, err
+	}
+	
+	env := []string{
+		"ACCEPT_EULA=yes",
+	}
+	if setup.UserName == "sa" {
+		env = append(env, fmt.Sprintf("SA_PASSWORD=%s", setup.Password))
+	}
+	
+	dbPort, err := freeport.GetFreePort()
+	if err != nil {
+		return nil, err
+	}
+
+	config := container.Config{
+		Image: image,
+		Env: env,
+	}
+	hostConfig := container.HostConfig{
+		PortBindings: nat.PortMap{
+			"1433/tcp": []nat.PortBinding{
+				{HostPort: fmt.Sprintf("%d/tcp", dbPort)},
+			},
+		},
+	}
 	networkConfig := network.NetworkingConfig{}
 
 	removeContainer(cli, containerName)
@@ -120,7 +164,7 @@ func SetupAdminDatabase(setup DatabaseSetup) (*MSSqlDatabaseSettings, error) {
 		return nil, err
 	}
 
-	settings, err := waitForDatabaseToBeReady(cli, create.ID, setup)
+	settings, err := waitForDatabaseToBeReady(cli, create.ID, setup, dbPort)
 	if err != nil {
 		return nil, err
 	}
@@ -128,69 +172,36 @@ func SetupAdminDatabase(setup DatabaseSetup) (*MSSqlDatabaseSettings, error) {
 	return settings, nil
 }
 
-// TeardownDatabase will teardown the test database
-func TeardownDatabase(testName string) {
+// TeardownMSSqlDatabase tears down the Microsoft SQL Server database
+func TeardownMSSqlDatabase(testName string) error {
 	os.Setenv("DOCKER_API_VERSION", "1.35")
 	cli, err := client.NewEnvClient()
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	removeContainer(cli, fmt.Sprintf("%s_database_test", testName))
+	removeContainer(cli, fmt.Sprintf("%s_mssql", testName))
+
+	return nil
 }
 
 func removeContainer(client *client.Client, name string) {
 	client.ContainerRemove(context.Background(), name, types.ContainerRemoveOptions{Force: true})
 }
 
-func waitForDatabaseToBeReady(client *client.Client, id string, setup DatabaseSetup) (*MSSqlDatabaseSettings, error) {
-	inspect, err := client.ContainerInspect(context.Background(), id)
-	if err != nil {
-		return nil, err
-	}
-
+func waitForDatabaseToBeReady(client *client.Client, id string, setup DatabaseSetup, dbPort int) (*MSSqlDatabaseSettings, error) {
 	settings := &MSSqlDatabaseSettings{
-		Host:     inspect.NetworkSettings.IPAddress,
+		Host:     "localhost",
+		Port:     dbPort,
 		User:     setup.UserName,
 		Password: setup.Password,
 		Name:     setup.DatabaseName,
 	}
 
-	err = waitForDatabaseToBeOnline(60, settings)
+	err := settings.WaitForDatabaseToBeOnline(60)
 	if err != nil {
 		return nil, err
 	}
 
 	return settings, nil
-}
-
-func waitForDatabaseToBeOnline(secondsToWait int, settings *MSSqlDatabaseSettings) error {
-	query := url.Values{}
-	query.Add("app name", "util")
-
-	if settings.Name != nil {
-		query.Add("database", *settings.Name)
-	}
-
-	u := &url.URL{
-		Scheme:   "sqlserver",
-		User:     url.UserPassword(settings.User, settings.Password),
-		Host:     fmt.Sprintf("%s:%d", settings.Host, 1433),
-		RawQuery: query.Encode(),
-	}
-
-	db, err := sql.Open("sqlserver", u.String())
-	if err != nil {
-		return errors.Wrap(err, "opening sql failed")
-	}
-
-	for i := 0; i < secondsToWait; i++ {
-		err = db.Ping()
-		if err == nil {
-			return nil
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	return err
 }

--- a/testing/docker/mssql_setup_test.go
+++ b/testing/docker/mssql_setup_test.go
@@ -1,0 +1,34 @@
+package docker_test
+
+import (
+	"github.com/syncromatics/go-kit/testing/docker"
+)
+
+func ExampleSetupMSSqlDatabase() {
+	settings, err := docker.SetupMSSqlDatabase(docker.DatabaseSetup{
+		TestName: "test",
+		UserName: "sa",
+		Password: "superS3cureP@ssword", // The Microsoft SQL Server image has password complexity requirements by default
+	})
+	if err != nil {
+		panic(err)
+	}
+	
+	db, err := settings.GetDB()
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Ping()
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	docker.TeardownMSSqlDatabase("test")
+	// Output: 
+}

--- a/testing/docker/postgres_setup.go
+++ b/testing/docker/postgres_setup.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/docker/go-connections/nat"
+	"github.com/phayes/freeport"
 	"github.com/syncromatics/go-kit/database"
 
 	client "docker.io/go-docker"
@@ -19,7 +21,7 @@ var (
 	postgresImage = "postgres:10.2"
 )
 
-// SetupPostgresDatabase sets up a timescale database
+// SetupPostgresDatabase sets up a postgres database
 func SetupPostgresDatabase(testName string) (*sql.DB, *database.PostgresDatabaseSettings, error) {
 	os.Setenv("DOCKER_API_VERSION", "1.35")
 	cli, err := client.NewEnvClient()
@@ -42,6 +44,11 @@ func SetupPostgresDatabase(testName string) (*sql.DB, *database.PostgresDatabase
 		return nil, nil, err
 	}
 
+	dbPort, err := freeport.GetFreePort()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	config := container.Config{
 		Image: postgresImage,
 		Env: []string{
@@ -50,9 +57,13 @@ func SetupPostgresDatabase(testName string) (*sql.DB, *database.PostgresDatabase
 			"POSTGRES_DB=test",
 		},
 	}
-
-	hostConfig := container.HostConfig{}
-
+	hostConfig := container.HostConfig{
+		PortBindings: nat.PortMap{
+			"5432/tcp": []nat.PortBinding{
+				{HostPort: fmt.Sprintf("%d/tcp", dbPort)},
+			},
+		},
+	}
 	networkConfig := network.NetworkingConfig{}
 
 	removePostgresContainer(cli, testName)
@@ -75,7 +86,7 @@ func SetupPostgresDatabase(testName string) (*sql.DB, *database.PostgresDatabase
 		return nil, nil, err
 	}
 
-	db, settings, err := waitForPostgresToBeReady(cli, create.ID)
+	db, settings, err := waitForPostgresToBeReady(dbPort)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -101,20 +112,16 @@ func removePostgresContainer(client *client.Client, testName string) {
 	client.ContainerRemove(context.Background(), containerName, types.ContainerRemoveOptions{Force: true})
 }
 
-func waitForPostgresToBeReady(client *client.Client, id string) (*sql.DB, *database.PostgresDatabaseSettings, error) {
-	inspect, err := client.ContainerInspect(context.Background(), id)
-	if err != nil {
-		return nil, nil, err
-	}
-
+func waitForPostgresToBeReady(dbPort int) (*sql.DB, *database.PostgresDatabaseSettings, error) {
 	settings := database.PostgresDatabaseSettings{
-		Host:     inspect.NetworkSettings.IPAddress,
+		Host:     "localhost",
+		Port:     dbPort,
 		User:     "postgres",
 		Password: "postgres",
 		Name:     "test",
 	}
 
-	err = settings.WaitForDatabaseToBeOnline(60)
+	err := settings.WaitForDatabaseToBeOnline(60)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/testing/docker/postgres_setup_test.go
+++ b/testing/docker/postgres_setup_test.go
@@ -1,0 +1,25 @@
+package docker_test
+
+import (
+	"github.com/syncromatics/go-kit/testing/docker"
+)
+
+func ExampleSetupPostgresDatabase() {
+	db, _, err := docker.SetupPostgresDatabase("test")
+	if err != nil {
+		panic(err)
+	}
+	
+	err = db.Ping()
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	docker.TeardownPostgresDatabase("test")
+	// Output: 
+}

--- a/testing/docker/rabbitmq_setup_test.go
+++ b/testing/docker/rabbitmq_setup_test.go
@@ -1,0 +1,32 @@
+package docker_test
+
+import (
+	"fmt"
+
+	"github.com/syncromatics/go-kit/testing/docker"
+)
+
+func ExampleSetupRabbitMQ() {
+	amqpURL, err := docker.SetupRabbitMQ("test")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("amqpURL is set: %t\n", amqpURL != "")
+	/*
+	conn, err := amqp.Dial(amqpURL)
+	if err != nil {
+		panic(err)
+	}
+
+	// snip
+
+	err = conn.Close()
+	if err != nil {
+		panic(err)
+	}
+	*/
+	
+	docker.TeardownRabbitMQ("test")
+	// Output: amqpURL is set: true
+}

--- a/testing/docker/redis_setup.go
+++ b/testing/docker/redis_setup.go
@@ -10,7 +10,9 @@ import (
 	"docker.io/go-docker/api/types"
 	"docker.io/go-docker/api/types/container"
 	"docker.io/go-docker/api/types/network"
+	"github.com/docker/go-connections/nat"
 	goredis "github.com/go-redis/redis"
+	"github.com/phayes/freeport"
 	"github.com/syncromatics/go-kit/redis"
 )
 
@@ -41,10 +43,21 @@ func SetupRedis(testName string) (*goredis.Options, error) {
 		return nil, err
 	}
 
+	dbPort, err := freeport.GetFreePort()
+	if err != nil {
+		return nil, err
+	}
+
 	config := container.Config{
 		Image: redisImage,
 	}
-	hostConfig := container.HostConfig{}
+	hostConfig := container.HostConfig{
+		PortBindings: nat.PortMap{
+			"6379/tcp": []nat.PortBinding{
+				{HostPort: fmt.Sprintf("%d/tcp", dbPort)},
+			},
+		},
+	}
 	networkConfig := network.NetworkingConfig{}
 
 	removeRedisContainer(cli, testName)
@@ -67,7 +80,7 @@ func SetupRedis(testName string) (*goredis.Options, error) {
 		return nil, err
 	}
 
-	opts, err := waitForRedisToBeReady(cli, create.ID)
+	opts, err := waitForRedisToBeReady(cli, create.ID, dbPort)
 	if err != nil {
 		return nil, err
 	}
@@ -96,19 +109,14 @@ func getContainerName(testName string) string {
 	return fmt.Sprintf("%s_redis", testName)
 }
 
-func waitForRedisToBeReady(client *client.Client, id string) (*goredis.Options, error) {
-	inspect, err := client.ContainerInspect(context.Background(), id)
-	if err != nil {
-		return nil, err
-	}
-
-	ip := inspect.NetworkSettings.IPAddress
-	url := fmt.Sprintf("redis://%s:6379", ip)
+func waitForRedisToBeReady(client *client.Client, id string, dbPort int) (*goredis.Options, error) {
+	url := fmt.Sprintf("redis://localhost:%d", dbPort)
 
 	opts, err := goredis.ParseURL(url)
 	if err != nil {
 		return nil, err
 	}
+
 	err = redis.WaitForRedisToBeOnline(opts, 60)
 	if err != nil {
 		return nil, err

--- a/testing/docker/redis_setup_test.go
+++ b/testing/docker/redis_setup_test.go
@@ -1,0 +1,21 @@
+package docker_test
+
+import (
+	"github.com/syncromatics/go-kit/redis"
+	"github.com/syncromatics/go-kit/testing/docker"
+)
+
+func ExampleSetupRedis() {
+	options, err := docker.SetupRedis("test")
+	if err != nil {
+		panic(err)
+	}
+	
+	err = redis.WaitForRedisToBeOnline(options, 10)
+	if err != nil {
+		panic(err)
+	}
+	
+	docker.TeardownRedis("test")
+	// Output: 
+}


### PR DESCRIPTION
This allows the docker test functions to work on macOS and Windows where the networking works differently.

(Work done as a part of EN-5506)