### PR TITLE
(+semver: breaking) Updated testing/docker package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "go.testTimeout": "120s"
+}

--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/syncromatics/go-kit/cmd"
+	"github.com/syncromatics/go-kit/v2/cmd"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/database/mssql.go
+++ b/database/mssql.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"time"
 
+	// Imports the sqlserver driver
+	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/pkg/errors"
 )
 

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -14,6 +14,7 @@ import (
 // PostgresDatabaseSettings are the settings for a timescale database
 type PostgresDatabaseSettings struct {
 	Host     string
+	Port     int
 	User     string
 	Password string
 	Name     string
@@ -99,10 +100,18 @@ func (ds *PostgresDatabaseSettings) MigrateUpWithStatik(subdirectory string) err
 	return nil
 }
 
+func (ds *PostgresDatabaseSettings) getPort() int {
+	if ds.Port != 0 {
+		return ds.Port
+	}
+
+	return 5432
+}
+
 func (ds *PostgresDatabaseSettings) getConnectionStringWithoutDatabase() string {
-	return fmt.Sprintf("user=%s password=%s host=%s sslmode=disable", ds.User, ds.Password, ds.Host)
+	return fmt.Sprintf("user=%s password=%s host=%s port=%d sslmode=disable", ds.User, ds.Password, ds.Host, ds.getPort())
 }
 
 func (ds *PostgresDatabaseSettings) getConnectionStringWithDatabase() string {
-	return fmt.Sprintf("user=%s password=%s host=%s dbname=%s sslmode=disable", ds.User, ds.Password, ds.Host, ds.Name)
+	return fmt.Sprintf("user=%s password=%s host=%s port=%d dbname=%s sslmode=disable", ds.User, ds.Password, ds.Host, ds.getPort(), ds.Name)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/syncromatics/go-kit
+module github.com/syncromatics/go-kit/v2
 
 go 1.13
 
@@ -7,6 +7,8 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/Shopify/sarama v1.24.1
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
+	github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec
+	github.com/docker/go-connections v0.4.0
 	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/golang-migrate/migrate/v4 v4.8.0
 	github.com/golang/protobuf v1.3.2
@@ -15,15 +17,14 @@ require (
 	github.com/klauspost/cpuid v1.2.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/rakyll/statik v0.1.6
-	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/syncromatics/proto-schema-registry v0.7.2
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a
 	go.uber.org/zap v1.13.0
 	golang.org/x/net v0.0.0-20200513185701-a91f0712d120
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3 h1:tkum0XDgfR0jcVVXuTsYv/erY2NnEDqwRojbxR1rBYA=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
+github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec h1:NfhRXXFDPxcF5Cwo06DzeIaE7uuJtAUhsDwH3LNsjos=
+github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dhui/dktest v0.3.1 h1:NVUdB50k8tml431Ho1hcQBNeC52Qe8oSDPAjseA67Y8=
 github.com/dhui/dktest v0.3.1/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c1yc=
 github.com/docker/distribution v2.7.0+incompatible h1:neUDAlf3wX6Ml4HdqTrbcOHXtfRN0TFIwt6YFL7N9RU=
@@ -91,6 +93,8 @@ github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang-migrate/migrate/v4 v4.8.0 h1:zcamXqBH0W8hHwpaikOGnaFTRrQWU+X8ukBeY1dYucU=
 github.com/golang-migrate/migrate/v4 v4.8.0/go.mod h1:F6bGIGAA7xSb2k17sF1+eHl2gRHa+DWNZpoIKbThPLE=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -184,6 +188,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.2.6+incompatible h1:6aCX4/YZ9v8q69hTyiR7dNLnTA3fgtKHVVW5BCd5Znw=
 github.com/pierrec/lz4 v2.2.6+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -211,8 +217,6 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhD
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCLY7gIfzeQaUJ+kppEO5WQG3cL8iE8tGHU=
-github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -232,8 +236,6 @@ github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR8
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a h1:ILoU84rj4AQ3q6cjQvtb9jBjx4xzR/Riq/zYhmDQiOk=
-github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a/go.mod h1:vQQATAGxVK20DC1rRubTJbZDDhhpA4QfU02pMdPxGO4=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=

--- a/grpc/pingService.go
+++ b/grpc/pingService.go
@@ -1,7 +1,7 @@
 package grpc
 
 import (
-	pingv1 "github.com/syncromatics/go-kit/internal/protos/gokit/ping/v1"
+	pingv1 "github.com/syncromatics/go-kit/v2/internal/protos/gokit/ping/v1"
 
 	"golang.org/x/net/context"
 )

--- a/grpc/serviceCreator.go
+++ b/grpc/serviceCreator.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	pingv1 "github.com/syncromatics/go-kit/internal/protos/gokit/ping/v1"
+	pingv1 "github.com/syncromatics/go-kit/v2/internal/protos/gokit/ping/v1"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"

--- a/testing/docker/etcd_setup_test.go
+++ b/testing/docker/etcd_setup_test.go
@@ -1,0 +1,35 @@
+package docker_test
+
+import (
+	"fmt"
+
+	"github.com/syncromatics/go-kit/v2/testing/docker"
+)
+
+func ExampleSetupEtcd() {
+	etcdURL, err := docker.SetupEtcd("test")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("etcdURL is set: %t\n", etcdURL != "")
+	/*
+		cli, err := clientv3.New(clientv3.Config{
+			Endpoints:   []string{etcdURL},
+			DialTimeout: 5*time.Second,
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		// snip
+
+		err = cli.Close()
+		if err != nil {
+			panic(err)
+		}
+	*/
+
+	docker.TeardownEtcd("test")
+	// Output: etcdURL is set: true
+}

--- a/testing/docker/kafka_setup.go
+++ b/testing/docker/kafka_setup.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	client "docker.io/go-docker"
@@ -13,9 +14,10 @@ import (
 	"docker.io/go-docker/api/types/container"
 	"docker.io/go-docker/api/types/network"
 	"github.com/Shopify/sarama"
+	"github.com/docker/go-connections/nat"
+	"github.com/phayes/freeport"
 	"github.com/pkg/errors"
 	v1 "github.com/syncromatics/proto-schema-registry/pkg/proto/schema/registry/v1"
-	kazoo "github.com/wvanbergen/kazoo-go"
 	"google.golang.org/grpc"
 )
 
@@ -38,8 +40,8 @@ func (l *NoOpLogger) Panicf(msg string, args ...interface{}) {
 
 // KafkaSetup is the details about the kafka setup
 type KafkaSetup struct {
-	ZookeeperIP     string
-	ProtoRegistryIP string
+	ExternalBroker string
+	ProtoRegistry  string
 }
 
 // SetupKafka sets up the zookeeper and kafka test containers
@@ -67,27 +69,32 @@ func SetupKafka(testName string) (*KafkaSetup, error) {
 
 	removeContainers(cli, testName)
 
-	zookeeperIP, err := createZookeeperContainer(cli, testName)
-	if err != nil {
-		return nil, err
-	}
-	setup.ZookeeperIP = zookeeperIP
-
-	brokerIP, err := createKafkaContainer(cli, setup.ZookeeperIP, testName)
+	err = createKafkaNetwork(cli, testName)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = waitForBroker(setup.ZookeeperIP, 60*time.Second)
+	zookeeper, err := createZookeeperContainer(cli, testName)
 	if err != nil {
 		return nil, err
 	}
 
-	protoIP, err := createProtoRegistryContainer(cli, testName, brokerIP)
+	internalBroker, externalBroker, err := createKafkaContainer(cli, zookeeper, testName)
 	if err != nil {
 		return nil, err
 	}
-	setup.ProtoRegistryIP = protoIP
+	setup.ExternalBroker = externalBroker
+
+	err = ensureAdminConnectionToBroker(externalBroker, 60*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	protoRegistry, err := createProtoRegistryContainer(cli, testName, internalBroker)
+	if err != nil {
+		return nil, err
+	}
+	setup.ProtoRegistry = protoRegistry
 
 	return &setup, nil
 }
@@ -121,111 +128,170 @@ func pullImage(client *client.Client, image string) error {
 }
 
 func removeContainers(client *client.Client, testName string) {
-	client.ContainerRemove(context.Background(), fmt.Sprintf("%s_zookeeper_test", testName), types.ContainerRemoveOptions{Force: true})
-	client.ContainerRemove(context.Background(), fmt.Sprintf("%s_kafka_test", testName), types.ContainerRemoveOptions{Force: true})
-	client.ContainerRemove(context.Background(), fmt.Sprintf("%s_proto_registry_test", testName), types.ContainerRemoveOptions{Force: true})
+	client.ContainerRemove(context.Background(), fmt.Sprintf("%s_kafka_zk", testName), types.ContainerRemoveOptions{Force: true})
+	client.ContainerRemove(context.Background(), fmt.Sprintf("%s_kafka_broker", testName), types.ContainerRemoveOptions{Force: true})
+	client.ContainerRemove(context.Background(), fmt.Sprintf("%s_kafka_pr", testName), types.ContainerRemoveOptions{Force: true})
+	client.NetworkRemove(context.Background(), fmt.Sprintf("%s_kafka", testName))
 }
 
-func createZookeeperContainer(cli *client.Client, testName string) (string, error) {
+func createKafkaNetwork(cli *client.Client, testName string) error {
+	networkName := fmt.Sprintf("%s_kafka", testName)
+	config := types.NetworkCreate{
+		Driver: "bridge",
+	}
+
+	_, err := cli.NetworkCreate(context.Background(), networkName, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+func createZookeeperContainer(cli *client.Client, testName string) ([]string, error) {
+	zkPort, err := freeport.GetFreePort()
+	if err != nil {
+		return nil, err
+	}
+
 	config := container.Config{
 		Image: zookeeperImage,
 		Env: []string{
 			"ZOOKEEPER_CLIENT_PORT=2181",
-		}}
-
-	hostConfig := container.HostConfig{}
-
+		},
+	}
+	hostConfig := container.HostConfig{
+		PortBindings: nat.PortMap{
+			"2181/tcp": []nat.PortBinding{
+				{HostPort: fmt.Sprintf("%d/tcp", zkPort)},
+			},
+		},
+	}
 	networkConfig := network.NetworkingConfig{}
 
-	create, err := cli.ContainerCreate(context.Background(), &config, &hostConfig, &networkConfig, fmt.Sprintf("%s_zookeeper_test", testName))
+	hostname := fmt.Sprintf("%s_kafka_zk", testName)
+	create, err := cli.ContainerCreate(context.Background(), &config, &hostConfig, &networkConfig, hostname)
 	if err != nil {
-		return "", err
+		return nil, err
+	}
+
+	err = cli.NetworkConnect(context.Background(), fmt.Sprintf("%s_kafka", testName), create.ID, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	conChan, errChan := cli.ContainerWait(context.Background(), create.ID, container.WaitConditionNotRunning)
 	select {
 	case err = <-errChan:
-		return "", err
+		return nil, err
 	case <-conChan:
 	}
 
 	err = cli.ContainerStart(context.Background(), create.ID, types.ContainerStartOptions{})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	inspect, err := cli.ContainerInspect(context.Background(), create.ID)
-	if err != nil {
-		return "", err
-	}
-
-	return inspect.NetworkSettings.IPAddress, nil
+	return []string{
+		fmt.Sprintf("%s:2181", hostname),
+		fmt.Sprintf("localhost:%d", zkPort),
+	}, nil
 }
 
-func createKafkaContainer(cli *client.Client, zookeeperIP string, testName string) (string, error) {
+func createKafkaContainer(cli *client.Client, zookeeperIP []string, testName string) (string, string, error) {
+	kafkaPort, err := freeport.GetFreePort()
+	if err != nil {
+		return "", "", err
+	}
+
+	hostname := fmt.Sprintf("%s_kafka_broker", testName)
 	config := container.Config{
 		Image: kafkaImage,
 		Env: []string{
-			"HOST_IP=kafka",
+			fmt.Sprintf("HOST_IP=%s", hostname),
 			"KAFKA_NUM_PARTITIONS=10",
 			"KAFKA_DEFAULT_REPLICATION_FACTOR=1",
 			"KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1",
 			"KAFKA_REPLICATION_FACTOR=1",
 			"KAFKA_BROKER_ID=1",
-			fmt.Sprintf("KAFKA_ZOOKEEPER_CONNECT=%s", zookeeperIP),
+			fmt.Sprintf("KAFKA_ZOOKEEPER_CONNECT=%s", strings.Join(zookeeperIP, ",")),
+			"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INT:PLAINTEXT,EXT:PLAINTEXT",
+			"KAFKA_LISTENERS=INT://:9090,EXT://:9092",
+			fmt.Sprintf("KAFKA_ADVERTISED_LISTENERS=INT://:9090,EXT://localhost:%d", kafkaPort),
+			"KAFKA_INTER_BROKER_LISTENER_NAME=INT",
 		},
 		Entrypoint: nil,
 		Cmd: []string{
 			"/bin/sh",
 			"-c",
-			"export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$(hostname -i):9092 && exec /etc/confluent/docker/run",
+			"exec /etc/confluent/docker/run",
 		},
 	}
-
-	hostConfig := container.HostConfig{}
-
+	hostConfig := container.HostConfig{
+		PortBindings: nat.PortMap{
+			"9092/tcp": []nat.PortBinding{
+				{HostPort: fmt.Sprintf("%d/tcp", kafkaPort)},
+			},
+		},
+	}
 	networkConfig := network.NetworkingConfig{}
 
-	create, err := cli.ContainerCreate(context.Background(), &config, &hostConfig, &networkConfig, fmt.Sprintf("%s_kafka_test", testName))
+	create, err := cli.ContainerCreate(context.Background(), &config, &hostConfig, &networkConfig, hostname)
 	if err != nil {
-		return "", err
+		return "", "", err
+	}
+
+	err = cli.NetworkConnect(context.Background(), fmt.Sprintf("%s_kafka", testName), create.ID, nil)
+	if err != nil {
+		return "", "", err
 	}
 
 	conChan, errChan := cli.ContainerWait(context.Background(), create.ID, container.WaitConditionNotRunning)
 	select {
 	case err = <-errChan:
-		return "", err
+		return "", "", err
 	case <-conChan:
 	}
 
 	err = cli.ContainerStart(context.Background(), create.ID, types.ContainerStartOptions{})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	inspect, err := cli.ContainerInspect(context.Background(), create.ID)
-	if err != nil {
-		return "", err
-	}
-
-	return inspect.NetworkSettings.IPAddress, nil
+	return fmt.Sprintf("%s:9090", hostname), fmt.Sprintf("localhost:%d", kafkaPort), nil
 }
 
 func createProtoRegistryContainer(cli *client.Client, testName string, brokerIP string) (string, error) {
+	registryPort, err := freeport.GetFreePort()
+	if err != nil {
+		return "", err
+	}
+
 	config := container.Config{
 		Image: registryImage,
 		Env: []string{
-			fmt.Sprintf("KAFKA_BROKER=%s:9092", brokerIP),
+			fmt.Sprintf("KAFKA_BROKER=%s", brokerIP),
 			"PORT=443",
 			"REPLICATION_FACTOR=1",
 		},
+		ExposedPorts: nat.PortSet{
+			"443/tcp": struct{}{},
+		},
 	}
-
-	hostConfig := container.HostConfig{}
-
+	hostConfig := container.HostConfig{
+		PortBindings: nat.PortMap{
+			"443/tcp": []nat.PortBinding{
+				{HostPort: fmt.Sprintf("%d/tcp", registryPort)},
+			},
+		},
+	}
 	networkConfig := network.NetworkingConfig{}
 
-	create, err := cli.ContainerCreate(context.Background(), &config, &hostConfig, &networkConfig, fmt.Sprintf("%s_proto_registry_test", testName))
+	create, err := cli.ContainerCreate(context.Background(), &config, &hostConfig, &networkConfig, fmt.Sprintf("%s_kafka_pr", testName))
+	if err != nil {
+		return "", err
+	}
+
+	err = cli.NetworkConnect(context.Background(), fmt.Sprintf("%s_kafka", testName), create.ID, nil)
 	if err != nil {
 		return "", err
 	}
@@ -242,12 +308,8 @@ func createProtoRegistryContainer(cli *client.Client, testName string, brokerIP 
 		return "", err
 	}
 
-	inspect, err := cli.ContainerInspect(context.Background(), create.ID)
-	if err != nil {
-		return "", err
-	}
-
-	con, err := grpc.Dial(fmt.Sprintf("%s:443", inspect.NetworkSettings.IPAddress), grpc.WithInsecure())
+	target := fmt.Sprintf("localhost:%d", registryPort)
+	con, err := grpc.Dial(target, grpc.WithInsecure())
 	if err != nil {
 		return "", errors.Wrap(err, "failed to dial server")
 	}
@@ -264,60 +326,17 @@ func createProtoRegistryContainer(cli *client.Client, testName string, brokerIP 
 		return "", errors.Wrap(err, "failed to ping server")
 	}
 
-	return inspect.NetworkSettings.IPAddress, nil
+	return target, nil
 }
 
-func waitForBroker(zookeeperHost string, duration time.Duration) ([]string, error) {
-	start := time.Now()
-	for time.Now().Sub(start) < duration {
-		var kz *kazoo.Kazoo
-		logger := NoOpLogger{}
-		kzConfig := kazoo.NewConfig()
-		kzConfig.Logger = &logger
-
-		kz, err := kazoo.NewKazoo([]string{zookeeperHost}, kzConfig)
-		if err != nil {
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		brokersMap, err := kz.Brokers()
-		if err != nil {
-			kz.Close()
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		if len(brokersMap) > 0 {
-			kz.Close()
-			brokers := []string{}
-			for _, broker := range brokersMap {
-				brokers = append(brokers, broker)
-			}
-
-			err = ensureAdminConnectionToBroker(brokers, duration)
-			if err != nil {
-				return nil, err
-			}
-			return brokers, nil
-		}
-
-		time.Sleep(1 * time.Second)
-
-		kz.Close()
-	}
-
-	return nil, fmt.Errorf("cannot get brokers")
-}
-
-func ensureAdminConnectionToBroker(brokers []string, duration time.Duration) error {
+func ensureAdminConnectionToBroker(brokerIP string, duration time.Duration) error {
 	config := sarama.NewConfig()
 	config.Version = sarama.V2_0_0_0
 
 	start := time.Now()
 	var lastErr error
 	for time.Now().Sub(start) < duration {
-		clusterAdmin, err := sarama.NewClusterAdmin(brokers, config)
+		clusterAdmin, err := sarama.NewClusterAdmin([]string{brokerIP}, config)
 		if err != nil {
 			lastErr = errors.Wrap(err, "failed connecting with sarama")
 			continue

--- a/testing/docker/kafka_setup_test.go
+++ b/testing/docker/kafka_setup_test.go
@@ -1,0 +1,19 @@
+package docker_test
+
+import (
+	"fmt"
+
+	"github.com/syncromatics/go-kit/v2/testing/docker"
+)
+
+func ExampleSetupKafka() {
+	setup, err := docker.SetupKafka("test")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Kafka broker and proto registry hosts are set: %t", setup.ExternalBroker != "" && setup.ProtoRegistry != "")
+
+	docker.TeardownKafka("test")
+	// Output: Kafka broker and proto registry hosts are set: true
+}

--- a/testing/docker/mssql_setup_test.go
+++ b/testing/docker/mssql_setup_test.go
@@ -1,0 +1,34 @@
+package docker_test
+
+import (
+	"github.com/syncromatics/go-kit/v2/testing/docker"
+)
+
+func ExampleSetupMSSqlDatabase() {
+	settings, err := docker.SetupMSSqlDatabase(docker.DatabaseSetup{
+		TestName: "test",
+		UserName: "sa",
+		Password: "superS3cureP@ssword", // The Microsoft SQL Server image has password complexity requirements by default
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	db, err := settings.GetDB()
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Ping()
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	docker.TeardownMSSqlDatabase("test")
+	// Output:
+}

--- a/testing/docker/postgres_setup_test.go
+++ b/testing/docker/postgres_setup_test.go
@@ -1,0 +1,25 @@
+package docker_test
+
+import (
+	"github.com/syncromatics/go-kit/v2/testing/docker"
+)
+
+func ExampleSetupPostgresDatabase() {
+	db, _, err := docker.SetupPostgresDatabase("test")
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Ping()
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	docker.TeardownPostgresDatabase("test")
+	// Output:
+}

--- a/testing/docker/rabbitmq_setup.go
+++ b/testing/docker/rabbitmq_setup.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"time"
 
@@ -13,24 +12,23 @@ import (
 	"docker.io/go-docker/api/types"
 	"docker.io/go-docker/api/types/container"
 	"docker.io/go-docker/api/types/network"
-	"docker.io/go-docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
 	"github.com/phayes/freeport"
 )
 
 var (
-	etcdImage = "quay.io/coreos/etcd:v3.4.3"
+	rabbitMqImage = "rabbitmq:3.7.7-management"
 )
 
-// SetupEtcd sets up a etcd database
-func SetupEtcd(testName string) (string, error) {
+// SetupRabbitMQ sets up a RabbitMQ broker
+func SetupRabbitMQ(testName string) (string, error) {
 	os.Setenv("DOCKER_API_VERSION", "1.35")
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		return "", err
 	}
 
-	r, err := cli.ImagePull(context.Background(), etcdImage, types.ImagePullOptions{})
+	r, err := cli.ImagePull(context.Background(), rabbitMqImage, types.ImagePullOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -50,39 +48,38 @@ func SetupEtcd(testName string) (string, error) {
 		return "", err
 	}
 
-	grpcPort, metricsPort := ports[0], ports[1]
+	amqpPort, managementPort := ports[0], ports[1]
 
+	// Taken from https://github.com/docker-library/healthcheck/blob/master/rabbitmq/docker-healthcheck
+	healthcheckScript := `rabbitmqctl eval '
+{ true, rabbit_app_booted_and_running } = { rabbit:is_booted(node()), rabbit_app_booted_and_running },
+{ [], no_alarms } = { rabbit:alarms(), no_alarms },
+[] /= rabbit_networking:active_listeners(),
+rabbitmq_node_is_healthy.
+' || exit 1`
 	config := container.Config{
-		Image: etcdImage,
-		Cmd: strslice.StrSlice([]string{
-			"/usr/local/bin/etcd",
-			"-advertise-client-urls",
-			"http://0.0.0.0:2379",
-			"-listen-client-urls",
-			"http://0.0.0.0:2379",
-			"--listen-metrics-urls",
-			"http://0.0.0.0:4001",
-		}),
-		ExposedPorts: nat.PortSet{
-			"2379/tcp": struct{}{},
-			"4001/tcp": struct{}{},
+		Image: rabbitMqImage,
+		Healthcheck: &container.HealthConfig{
+			Test:     []string{"CMD-SHELL", healthcheckScript},
+			Interval: 1 * time.Second,
+			Retries:  30,
 		},
 	}
 	hostConfig := container.HostConfig{
 		PortBindings: nat.PortMap{
-			"2379/tcp": []nat.PortBinding{
-				{HostPort: fmt.Sprintf("%d/tcp", grpcPort)},
+			"5672/tcp": []nat.PortBinding{
+				{HostPort: fmt.Sprintf("%d/tcp", amqpPort)},
 			},
-			"4001/tcp": []nat.PortBinding{
-				{HostPort: fmt.Sprintf("%d/tcp", metricsPort)},
+			"15672/tcp": []nat.PortBinding{
+				{HostPort: fmt.Sprintf("%d/tcp", managementPort)},
 			},
 		},
 	}
 	networkConfig := network.NetworkingConfig{}
 
-	removeEtcdContainer(cli, testName)
+	removeRabbitMQContainer(cli, testName)
 
-	containerName := fmt.Sprintf("%s_etcd_db", testName)
+	containerName := fmt.Sprintf("%s_rabbitmq", testName)
 	create, err := cli.ContainerCreate(context.Background(), &config, &hostConfig, &networkConfig, containerName)
 	if err != nil {
 		return "", err
@@ -100,34 +97,32 @@ func SetupEtcd(testName string) (string, error) {
 		return "", err
 	}
 
-	db, err := waitForEtcdToBeReady(cli, create.ID, grpcPort, metricsPort)
+	url, err := waitForRabbitMQToBeReady(cli, create.ID, amqpPort)
 	if err != nil {
 		return "", err
 	}
 
-	return db, nil
+	return url, nil
 }
 
-// TeardownEtcd tears down the etcd db
-func TeardownEtcd(testName string) error {
+// TeardownRabbitMQ tears down the RabbitMQ broker
+func TeardownRabbitMQ(testName string) error {
 	os.Setenv("DOCKER_API_VERSION", "1.35")
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		return err
 	}
 
-	removeEtcdContainer(cli, testName)
-
+	removeRabbitMQContainer(cli, testName)
 	return nil
 }
 
-func removeEtcdContainer(client *client.Client, testName string) {
-	containerName := fmt.Sprintf("%s_etcd_db", testName)
+func removeRabbitMQContainer(client *client.Client, testName string) {
+	containerName := fmt.Sprintf("%s_rabbitmq", testName)
 	client.ContainerRemove(context.Background(), containerName, types.ContainerRemoveOptions{Force: true})
 }
 
-func waitForEtcdToBeReady(client *client.Client, id string, grpcPort, metricsPort int) (string, error) {
-	healthURL := fmt.Sprintf("http://localhost:%d/health", metricsPort)
+func waitForRabbitMQToBeReady(client *client.Client, id string, amqpPort int) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	for {
@@ -136,19 +131,14 @@ func waitForEtcdToBeReady(client *client.Client, id string, grpcPort, metricsPor
 			cancel()
 			return "", errors.New("failed to start container in a timely manner")
 		case <-time.After(1 * time.Second):
-			req, err := http.NewRequestWithContext(ctx, "GET", healthURL, nil)
+			inspect, err := client.ContainerInspect(ctx, id)
 			if err != nil {
 				continue
 			}
 
-			response, err := http.DefaultClient.Do(req)
-			if err != nil {
-				continue
-			}
-
-			if response.StatusCode == http.StatusOK {
+			if inspect.State.Health.Status == "healthy" {
 				cancel()
-				return fmt.Sprintf("localhost:%d", grpcPort), nil
+				return fmt.Sprintf("amqp://guest:guest@localhost:%d", amqpPort), nil
 			}
 		}
 	}

--- a/testing/docker/rabbitmq_setup_test.go
+++ b/testing/docker/rabbitmq_setup_test.go
@@ -1,0 +1,32 @@
+package docker_test
+
+import (
+	"fmt"
+
+	"github.com/syncromatics/go-kit/v2/testing/docker"
+)
+
+func ExampleSetupRabbitMQ() {
+	amqpURL, err := docker.SetupRabbitMQ("test")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("amqpURL is set: %t\n", amqpURL != "")
+	/*
+		conn, err := amqp.Dial(amqpURL)
+		if err != nil {
+			panic(err)
+		}
+
+		// snip
+
+		err = conn.Close()
+		if err != nil {
+			panic(err)
+		}
+	*/
+
+	docker.TeardownRabbitMQ("test")
+	// Output: amqpURL is set: true
+}

--- a/testing/docker/redis_setup_test.go
+++ b/testing/docker/redis_setup_test.go
@@ -1,0 +1,21 @@
+package docker_test
+
+import (
+	"github.com/syncromatics/go-kit/v2/redis"
+	"github.com/syncromatics/go-kit/v2/testing/docker"
+)
+
+func ExampleSetupRedis() {
+	options, err := docker.SetupRedis("test")
+	if err != nil {
+		panic(err)
+	}
+
+	err = redis.WaitForRedisToBeOnline(options, 10)
+	if err != nil {
+		panic(err)
+	}
+
+	docker.TeardownRedis("test")
+	// Output:
+}


### PR DESCRIPTION
This is a proper bump to the module version. The new module path is `github.com/syncromatics/go-kit/v2` and will be tagged as such.

---

(+semver: breaking) Updated testing/docker package

- Unified names of functions across docker package
- Updated module to v2
- Added RabbitMQ support
- Added test coverage
- Added postgres port support