### PR TITLE
(+semver: feature) Promoted ProcessGroup from internal emergency-service project

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -6,8 +6,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/syncromatics/go-kit/log"
-
 	"golang.org/x/sync/errgroup"
 )
 
@@ -50,8 +48,6 @@ func (gw *ProcessGroup) Wait() error {
 
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
-	log.Info("started process")
-
 	errs := make(chan error)
 	defer close(errs)
 	go func(group *errgroup.Group, ctx context.Context) {
@@ -61,15 +57,12 @@ func (gw *ProcessGroup) Wait() error {
 
 	for {
 		select {
-		case sig := <-signals:
-			log.Debug("caught signal", "signal", sig)
+		case <-signals:
 			gw.cancel()
 		case <-gw.ctx.Done():
-			log.Debug("cancelled context")
 			err := <-errs
 			return err
 		case err := <-errs:
-			log.Debug("process group wait completed")
 			return err
 		}
 	}

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/syncromatics/go-kit/log"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// ProcessGroup is an errgroup that listens for OS process signals
+type ProcessGroup struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	group  *errgroup.Group
+}
+
+// NewProcessGroup creates a new ProcessGroup
+func NewProcessGroup(outerCtx context.Context) *ProcessGroup {
+	ctx, cancel := context.WithCancel(outerCtx)
+	group, ctx := errgroup.WithContext(ctx)
+	return &ProcessGroup{
+		ctx,
+		cancel,
+		group,
+	}
+}
+
+// Context returns the context used by the ProcessGroup
+func (gw *ProcessGroup) Context() context.Context {
+	return gw.ctx
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (gw *ProcessGroup) Go(f func() error) {
+	gw.group.Go(f)
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (gw *ProcessGroup) Wait() error {
+	signals := make(chan os.Signal)
+	defer close(signals)
+
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	log.Info("started process")
+
+	select {
+	case sig := <-signals:
+		log.Debug("caught signal", "signal", sig)
+	case <-gw.ctx.Done():
+		log.Debug("cancelled context")
+	}
+
+	log.Info("stopping process")
+
+	gw.cancel()
+
+	err := gw.group.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -1,0 +1,47 @@
+package cmd_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/syncromatics/go-kit/cmd"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ProcessGroup_Success(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	group := cmd.NewProcessGroup(ctx)
+
+	group.Go(func() error {
+		cancel()
+
+		select {
+		case <-group.Context().Done():
+			return nil
+		case <-time.After(3 * time.Second):
+			return errors.New("group context not derived from input context")
+		}
+	})
+
+	err := group.Wait()
+	assert.Nil(t, err)
+}
+
+func Test_ProcessGroup_Failure(t *testing.T) {
+	ctx := context.Background()
+	group := cmd.NewProcessGroup(ctx)
+
+	group.Go(func() error {
+		return nil
+	})
+	group.Go(func() error {
+		return errors.New("intentional failure")
+	})
+
+	err := group.Wait()
+	assert.Equal(t, "intentional failure", err.Error())
+
+}

--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -30,6 +30,17 @@ func Test_ProcessGroup_Success(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func Test_ProcessGroup_SuccessWithoutContextCancellation(t *testing.T) {
+	group := cmd.NewProcessGroup(context.Background())
+
+	group.Go(func() error {
+		return nil
+	})
+
+	err := group.Wait()
+	assert.Nil(t, err)
+}
+
 func Test_ProcessGroup_Failure(t *testing.T) {
 	ctx := context.Background()
 	group := cmd.NewProcessGroup(ctx)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/Shopify/sarama v1.24.1
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
-	github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3
 	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/golang-migrate/migrate/v4 v4.8.0
 	github.com/golang/protobuf v1.3.2
@@ -20,12 +19,14 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/rakyll/statik v0.1.6
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/syncromatics/proto-schema-registry v0.7.2
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a
 	go.uber.org/zap v1.13.0
 	golang.org/x/net v0.0.0-20200513185701-a91f0712d120
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 // indirect
 	google.golang.org/grpc v1.25.1
 )

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
ProcessGroup is an implementation that has the same interface as errgroup, but also listens for OS signals. This encapsulates a pattern for commands that we use in most of our services.