### PR TITLE
Add database keepalive pings.

### DIFF
--- a/database/keepalive.go
+++ b/database/keepalive.go
@@ -1,0 +1,40 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// SendKeepalivePings will periodically send a lightweight query to a database
+// in order to keep active, idle connections from being killed by an external
+// source.
+func SendKeepalivePings(ctx context.Context, db *sql.DB, interval time.Duration) func() error {
+	return func() error {
+		err := sendPing(ctx, db)
+		if err != nil {
+			return errors.Wrap(err, "failed sending initial keepalive ping")
+		}
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				err = sendPing(ctx, db)
+				if err != nil {
+					return errors.Wrap(err, "failed sending keepalive ping")
+				}
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	}
+}
+
+func sendPing(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, "SELECT NULL;")
+	return err
+}

--- a/database/keepalive_test.go
+++ b/database/keepalive_test.go
@@ -1,0 +1,75 @@
+package database_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/syncromatics/go-kit/v2/database"
+	"golang.org/x/sync/errgroup"
+	"gotest.tools/assert"
+)
+
+var nullResult = sqlmock.NewResult(0, 0)
+
+func Test_SendKeepalivePings_Can_Ping_Continuously(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NilError(t, err)
+
+	// Seems like there should be an easier way to expect this 3 times. Once for
+	// the initial query, and then every 100ms for a 250ms total duration.
+	mock.ExpectExec("SELECT NULL").WillReturnResult(nullResult)
+	mock.ExpectExec("SELECT NULL").WillReturnResult(nullResult)
+	mock.ExpectExec("SELECT NULL").WillReturnResult(nullResult)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	interval := 100 * time.Millisecond
+	group, ctx := errgroup.WithContext(ctx)
+
+	group.Go(database.SendKeepalivePings(ctx, db, interval))
+	select {
+	case <-time.After(250 * time.Millisecond):
+		cancel()
+	case <-ctx.Done():
+	}
+
+	err = group.Wait()
+	assert.NilError(t, err)
+
+	err = mock.ExpectationsWereMet()
+	assert.NilError(t, err)
+}
+
+func Test_SendKeepalivePings_Can_Return_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NilError(t, err)
+
+	// Seems like there should be an easier way to expect this 3 times. Once for
+	// the initial query, and then every 100ms for a 250ms total duration.
+	mock.ExpectExec("SELECT NULL").WillReturnResult(nullResult)
+	mock.ExpectExec("SELECT NULL").WillReturnResult(nullResult)
+	mock.ExpectExec("SELECT NULL").WillReturnError(fmt.Errorf("broken pipe"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	interval := 100 * time.Millisecond
+	group, ctx := errgroup.WithContext(ctx)
+
+	group.Go(database.SendKeepalivePings(ctx, db, interval))
+	select {
+	case <-time.After(250 * time.Millisecond):
+		cancel()
+	case <-ctx.Done():
+	}
+
+	err = group.Wait()
+	assert.ErrorContains(t, err, "broken pipe")
+
+	err = mock.ExpectationsWereMet()
+	assert.NilError(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	docker.io/go-docker v1.0.0
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/Shopify/sarama v1.24.1
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
@@ -30,4 +31,5 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 // indirect
 	google.golang.org/grpc v1.25.1
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ClickHouse/clickhouse-go v1.3.12/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=


### PR DESCRIPTION
Some microservice infrastructure configurations (notably, our usage of istio on
kubernetes) will detect long-running idle connections and kill them.  This
causes an issue with the connection pooling implemented by some sql.DB drivers
that will assume that once a connection is open it will remain open
indefinitely.

This commit adds the SendKeepalivePings func to our database package so that we
can periodically send lightweight database queries and prevent the connection
from getting killed.

(+semver: feature)

Signed-off-by: Jeff Cuevas-Koch <jeff@cuevaskoch.com>